### PR TITLE
Replace user.id with user.token in useAuth

### DIFF
--- a/frontend/components/context/UserContext.ts
+++ b/frontend/components/context/UserContext.ts
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction, createContext } from "react";
 
 export interface User {
-  id: string;
+  token: string;
   name: string;
   type: string;
 }

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -57,7 +57,7 @@ export function LoginForm() {
 
       if (loginRes && loginRes.access_token) {
         const user = {
-          id: loginRes.access_token,
+          token: loginRes.access_token,
           name: username,
           type: selectedType as string,
         };


### PR DESCRIPTION
因為看起來現在認證都不是用 user.id ，都改成 token 了
所以就把 useAuth 中的 `user.id` 刪掉，改成用 `user.token`，並把 access token 存在那裡面(這部分有直接推在main上了[commit](https://github.com/NCCU-DB-FINAL/DB-Final/commit/cd0dd34f1c1d36f9bc8dfd8662529f8be26b4f01)）


使用上跟之前一樣：
```js
const { user, isLoggedIn } = useAuth();
const token = user?.token || "no_token";
```
